### PR TITLE
Add missing break to prevent showing toolip on focus when on="hover"

### DIFF
--- a/__test__/__snapshots__/index.test.js.snap
+++ b/__test__/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`it should close on click outside popup (closeOnDocumentClick = true ) 1`] = `
 <PopupTest
   closeOnDocumentClick={true}
-  triggerOn="click"
+  on="click"
 >
   <Popup
     arrow={true}
@@ -20,11 +20,7 @@ exports[`it should close on click outside popup (closeOnDocumentClick = true ) 1
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -35,7 +31,6 @@ exports[`it should close on click outside popup (closeOnDocumentClick = true ) 1
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -111,7 +106,7 @@ exports[`it should close on click outside popup (closeOnDocumentClick = true ) 1
 exports[`it should close on click outside popup (closeOnDocumentClick = true ) 2`] = `
 <PopupTest
   closeOnDocumentClick={true}
-  triggerOn="click"
+  on="click"
 >
   <Popup
     arrow={true}
@@ -128,11 +123,7 @@ exports[`it should close on click outside popup (closeOnDocumentClick = true ) 2
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -143,7 +134,6 @@ exports[`it should close on click outside popup (closeOnDocumentClick = true ) 2
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <Ref
       innerRef={[Function]}
@@ -176,11 +166,7 @@ exports[`it should render correctly  1`] = `
   mouseLeaveDelay={100}
   offsetX={0}
   offsetY={0}
-  on={
-    Array [
-      "click",
-    ]
-  }
+  on="click"
   onClose={[Function]}
   onOpen={[Function]}
   open={false}
@@ -191,221 +177,9 @@ exports[`it should render correctly  1`] = `
        Trigger
     </button>
   }
-  triggerOn="click"
 >
   popup content
 </Popup>
-`;
-
-exports[`it should render correctly on click   1`] = `
-<PopupTest>
-  <Popup
-    arrow={true}
-    arrowStyle={Object {}}
-    className=""
-    closeOnDocumentClick={true}
-    closeOnEscape={true}
-    contentStyle={Object {}}
-    defaultOpen={false}
-    keepTooltipInside={false}
-    lockScroll={false}
-    modal={false}
-    mouseEnterDelay={100}
-    mouseLeaveDelay={100}
-    offsetX={0}
-    offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
-    onClose={[Function]}
-    onOpen={[Function]}
-    open={false}
-    overlayStyle={Object {}}
-    position="bottom center"
-    trigger={
-      <button>
-         Trigger
-      </button>
-    }
-  >
-    <div
-      key="H"
-      style={
-        Object {
-          "left": "0px",
-          "position": "absolute",
-          "top": "0px",
-        }
-      }
-    />
-    <div
-      className="popup-overlay"
-      key="O"
-      onClick={[Function]}
-      style={
-        Object {
-          "bottom": "0",
-          "left": "0",
-          "position": "fixed",
-          "right": "0",
-          "top": "0",
-        }
-      }
-    />
-    <div
-      className="popup-content "
-      key="C"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "rgb(255, 255, 255)",
-          "border": "1px solid rgb(187, 187, 187)",
-          "boxShadow": "rgba(0, 0, 0, 0.2) 0px 1px 3px",
-          "padding": "5px",
-          "position": "absolute",
-          "width": "200px",
-          "zIndex": "2",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "background": "rgb(255, 255, 255)",
-            "boxShadow": "rgba(0, 0, 0, 0.2) 1px 1px 1px",
-            "height": "10px",
-            "margin": "-5px",
-            "position": "absolute",
-            "transform": "rotate(45deg)",
-            "width": "10px",
-            "zIndex": "-1",
-          }
-        }
-      />
-      popup content
-    </div>
-    <Ref
-      innerRef={[Function]}
-      key="R"
-    >
-      <button
-        key="T"
-        onClick={[Function]}
-      >
-         Trigger
-      </button>
-    </Ref>
-  </Popup>
-</PopupTest>
-`;
-
-exports[`it should render correctly on click (triggerOn = 'click')  1`] = `
-<PopupTest
-  triggerOn="click"
->
-  <Popup
-    arrow={true}
-    arrowStyle={Object {}}
-    className=""
-    closeOnDocumentClick={true}
-    closeOnEscape={true}
-    contentStyle={Object {}}
-    defaultOpen={false}
-    keepTooltipInside={false}
-    lockScroll={false}
-    modal={false}
-    mouseEnterDelay={100}
-    mouseLeaveDelay={100}
-    offsetX={0}
-    offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
-    onClose={[Function]}
-    onOpen={[Function]}
-    open={false}
-    overlayStyle={Object {}}
-    position="bottom center"
-    trigger={
-      <button>
-         Trigger
-      </button>
-    }
-    triggerOn="click"
-  >
-    <div
-      key="H"
-      style={
-        Object {
-          "left": "0px",
-          "position": "absolute",
-          "top": "0px",
-        }
-      }
-    />
-    <div
-      className="popup-overlay"
-      key="O"
-      onClick={[Function]}
-      style={
-        Object {
-          "bottom": "0",
-          "left": "0",
-          "position": "fixed",
-          "right": "0",
-          "top": "0",
-        }
-      }
-    />
-    <div
-      className="popup-content "
-      key="C"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "rgb(255, 255, 255)",
-          "border": "1px solid rgb(187, 187, 187)",
-          "boxShadow": "rgba(0, 0, 0, 0.2) 0px 1px 3px",
-          "padding": "5px",
-          "position": "absolute",
-          "width": "200px",
-          "zIndex": "2",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "background": "rgb(255, 255, 255)",
-            "boxShadow": "rgba(0, 0, 0, 0.2) 1px 1px 1px",
-            "height": "10px",
-            "margin": "-5px",
-            "position": "absolute",
-            "transform": "rotate(45deg)",
-            "width": "10px",
-            "zIndex": "-1",
-          }
-        }
-      />
-      popup content
-    </div>
-    <Ref
-      innerRef={[Function]}
-      key="R"
-    >
-      <button
-        key="T"
-        onClick={[Function]}
-      >
-         Trigger
-      </button>
-    </Ref>
-  </Popup>
-</PopupTest>
 `;
 
 exports[`it should render correctly on click and will update the the popup content text   1`] = `
@@ -710,111 +484,10 @@ exports[`it should render correctly on click and will update the trigger text   
 </PopupTriggerFunction>
 `;
 
-exports[`it should render correctly on hover (triggerOn = 'focus')  1`] = `
-<PopupTestInput
-  triggerOn="focus"
->
-  <Popup
-    arrow={true}
-    arrowStyle={Object {}}
-    className=""
-    closeOnDocumentClick={true}
-    closeOnEscape={true}
-    contentStyle={Object {}}
-    defaultOpen={false}
-    keepTooltipInside={false}
-    lockScroll={false}
-    modal={false}
-    mouseEnterDelay={100}
-    mouseLeaveDelay={100}
-    offsetX={0}
-    offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
-    onClose={[Function]}
-    onOpen={[Function]}
-    open={false}
-    overlayStyle={Object {}}
-    position="bottom center"
-    trigger={
-      <input
-        type="text"
-      />
-    }
-    triggerOn="focus"
-  >
-    <Ref
-      innerRef={[Function]}
-      key="R"
-    >
-      <input
-        key="T"
-        onClick={[Function]}
-        type="text"
-      />
-    </Ref>
-  </Popup>
-</PopupTestInput>
-`;
-
-exports[`it should render correctly on hover (triggerOn = 'hover')  1`] = `
-<PopupTest
-  triggerOn="hover"
->
-  <Popup
-    arrow={true}
-    arrowStyle={Object {}}
-    className=""
-    closeOnDocumentClick={true}
-    closeOnEscape={true}
-    contentStyle={Object {}}
-    defaultOpen={false}
-    keepTooltipInside={false}
-    lockScroll={false}
-    modal={false}
-    mouseEnterDelay={100}
-    mouseLeaveDelay={100}
-    offsetX={0}
-    offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
-    onClose={[Function]}
-    onOpen={[Function]}
-    open={false}
-    overlayStyle={Object {}}
-    position="bottom center"
-    trigger={
-      <button>
-         Trigger
-      </button>
-    }
-    triggerOn="hover"
-  >
-    <Ref
-      innerRef={[Function]}
-      key="R"
-    >
-      <button
-        key="T"
-        onClick={[Function]}
-      >
-         Trigger
-      </button>
-    </Ref>
-  </Popup>
-</PopupTest>
-`;
-
 exports[`it should rendered in the bottom center position   1`] = `
 <PopupTest
+  on="click"
   position="bottom center"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -831,11 +504,7 @@ exports[`it should rendered in the bottom center position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -846,7 +515,6 @@ exports[`it should rendered in the bottom center position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -921,8 +589,8 @@ exports[`it should rendered in the bottom center position   1`] = `
 
 exports[`it should rendered in the bottom left position   1`] = `
 <PopupTest
+  on="click"
   position="bottom left"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -939,11 +607,7 @@ exports[`it should rendered in the bottom left position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -954,7 +618,6 @@ exports[`it should rendered in the bottom left position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1029,8 +692,8 @@ exports[`it should rendered in the bottom left position   1`] = `
 
 exports[`it should rendered in the bottom right position   1`] = `
 <PopupTest
+  on="click"
   position="bottom right"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1047,11 +710,7 @@ exports[`it should rendered in the bottom right position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1062,7 +721,6 @@ exports[`it should rendered in the bottom right position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1137,8 +795,8 @@ exports[`it should rendered in the bottom right position   1`] = `
 
 exports[`it should rendered in the left bottom position   1`] = `
 <PopupTest
+  on="click"
   position="left bottom"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1155,11 +813,7 @@ exports[`it should rendered in the left bottom position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1170,7 +824,6 @@ exports[`it should rendered in the left bottom position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1245,8 +898,8 @@ exports[`it should rendered in the left bottom position   1`] = `
 
 exports[`it should rendered in the left center position   1`] = `
 <PopupTest
+  on="click"
   position="left center"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1263,11 +916,7 @@ exports[`it should rendered in the left center position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1278,7 +927,6 @@ exports[`it should rendered in the left center position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1353,8 +1001,8 @@ exports[`it should rendered in the left center position   1`] = `
 
 exports[`it should rendered in the left top position   1`] = `
 <PopupTest
+  on="click"
   position="left top"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1371,11 +1019,7 @@ exports[`it should rendered in the left top position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1386,7 +1030,6 @@ exports[`it should rendered in the left top position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1461,8 +1104,8 @@ exports[`it should rendered in the left top position   1`] = `
 
 exports[`it should rendered in the right bottom position   1`] = `
 <PopupTest
+  on="click"
   position="right bottom"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1479,11 +1122,7 @@ exports[`it should rendered in the right bottom position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1494,7 +1133,6 @@ exports[`it should rendered in the right bottom position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1569,8 +1207,8 @@ exports[`it should rendered in the right bottom position   1`] = `
 
 exports[`it should rendered in the right center position   1`] = `
 <PopupTest
+  on="click"
   position="right center"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1587,11 +1225,7 @@ exports[`it should rendered in the right center position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1602,7 +1236,6 @@ exports[`it should rendered in the right center position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1677,8 +1310,8 @@ exports[`it should rendered in the right center position   1`] = `
 
 exports[`it should rendered in the right top position   1`] = `
 <PopupTest
+  on="click"
   position="right top"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1695,11 +1328,7 @@ exports[`it should rendered in the right top position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1710,7 +1339,6 @@ exports[`it should rendered in the right top position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1785,8 +1413,8 @@ exports[`it should rendered in the right top position   1`] = `
 
 exports[`it should rendered in the top center position   1`] = `
 <PopupTest
+  on="click"
   position="top center"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1803,11 +1431,7 @@ exports[`it should rendered in the top center position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1818,7 +1442,6 @@ exports[`it should rendered in the top center position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -1893,8 +1516,8 @@ exports[`it should rendered in the top center position   1`] = `
 
 exports[`it should rendered in the top left position   1`] = `
 <PopupTest
+  on="click"
   position="top left"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -1911,11 +1534,7 @@ exports[`it should rendered in the top left position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -1926,7 +1545,6 @@ exports[`it should rendered in the top left position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -2001,8 +1619,8 @@ exports[`it should rendered in the top left position   1`] = `
 
 exports[`it should rendered in the top right position   1`] = `
 <PopupTest
+  on="click"
   position="top right"
-  triggerOn="click"
 >
   <Popup
     arrow={true}
@@ -2019,11 +1637,7 @@ exports[`it should rendered in the top right position   1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -2034,7 +1648,6 @@ exports[`it should rendered in the top right position   1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -2109,7 +1722,7 @@ exports[`it should rendered in the top right position   1`] = `
 
 exports[`it shouldn't close on click outside popup  1`] = `
 <PopupTest
-  triggerOn="click"
+  on="click"
 >
   <Popup
     arrow={true}
@@ -2126,11 +1739,7 @@ exports[`it shouldn't close on click outside popup  1`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -2141,7 +1750,6 @@ exports[`it shouldn't close on click outside popup  1`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <div
       key="H"
@@ -2216,7 +1824,7 @@ exports[`it shouldn't close on click outside popup  1`] = `
 
 exports[`it shouldn't close on click outside popup  2`] = `
 <PopupTest
-  triggerOn="click"
+  on="click"
 >
   <Popup
     arrow={true}
@@ -2233,11 +1841,7 @@ exports[`it shouldn't close on click outside popup  2`] = `
     mouseLeaveDelay={100}
     offsetX={0}
     offsetY={0}
-    on={
-      Array [
-        "click",
-      ]
-    }
+    on="click"
     onClose={[Function]}
     onOpen={[Function]}
     open={false}
@@ -2248,7 +1852,6 @@ exports[`it shouldn't close on click outside popup  2`] = `
          Trigger
       </button>
     }
-    triggerOn="click"
   >
     <Ref
       innerRef={[Function]}

--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -3,17 +3,13 @@ import { shallow, mount } from "enzyme";
 import Enzyme from "enzyme";
 import Popup from "../src/Popup";
 import { shallowToJson } from "enzyme-to-json";
+import { cleanup, fireEvent, render, waitForElement } from "react-testing-library";
 
 import Adapter from "enzyme-adapter-react-16";
 Enzyme.configure({ adapter: new Adapter() });
 
 const PopupTest = props => (
   <Popup {...props} trigger={<button> Trigger</button>}>
-    popup content
-  </Popup>
-);
-const PopupTestInput = props => (
-  <Popup {...props} trigger={<input type="text" />}>
     popup content
   </Popup>
 );
@@ -30,31 +26,40 @@ const PopupContentAsFunction = props => (
     {(close, open) => <div> Popup content {open ? "open" : "close"} </div>}
   </Popup>
 );
+
+afterEach(() => cleanup());
+
 test("it should render correctly ", () => {
-  const popup = shallow(<PopupTest triggerOn="click" />);
+  const popup = shallow(<PopupTest on="click" />);
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should render correctly on click  ", () => {
-  const popup = mount(<PopupTest />);
-  popup.find("button").simulate("click");
-  expect(shallowToJson(popup)).toMatchSnapshot();
+  const { getByText } = render(<PopupTest />);
+  fireEvent.click(getByText("Trigger"));
+  expect(getByText("popup content")).toBeDefined();
 });
 
-test("it should render correctly on click (triggerOn = 'click') ", () => {
-  const popup = mount(<PopupTest triggerOn="click" />);
-  popup.find("button").simulate("click");
-  expect(shallowToJson(popup)).toMatchSnapshot();
+test("it should render correctly on click (on = 'click') ", () => {
+  const { getByText } = render(<PopupTest on="click"/>);
+  fireEvent.click(getByText("Trigger"));
+  expect(getByText("popup content")).toBeDefined();
 });
 
-test("it should render correctly on hover (triggerOn = 'hover') ", () => {
-  const popup = mount(<PopupTest triggerOn="hover" />);
-  popup.find("button").simulate("mouseEnter");
-  expect(shallowToJson(popup)).toMatchSnapshot();
+test("it should render correctly on hover (on = 'hover') ", async () => {
+  const { getByText } = render(<PopupTest on="hover" />);
+  fireEvent.mouseOver(getByText("Trigger"));
+  await waitForElement(() => getByText("popup content"));
 });
-test("it should render correctly on hover (triggerOn = 'focus') ", () => {
-  const popup = mount(<PopupTestInput triggerOn="focus" />);
-  popup.find("input").simulate("focus");
-  expect(shallowToJson(popup)).toMatchSnapshot();
+test("it should not render on hover (on = 'focus') ", async () => {
+  const { getByText, queryByText } = render(<PopupTest on="focus" />);
+  fireEvent.mouseOver(getByText("Trigger"));
+  expect(queryByText("popup content")).toBeNull();
+});
+
+test("it should not render on focus (on = 'hover') ", () => {
+  const { getByText, queryByText } = render(<PopupTest on="hover" />);
+  fireEvent.focus(getByText("Trigger"));
+  expect(queryByText("popup content")).toBeNull();
 });
 
 // trigger as function
@@ -79,7 +84,7 @@ test("it should render correctly on click and will update the the popup content 
 // closeOnDocumentClick Tests PopupContentAsFunction
 
 test("it shouldn't close on click outside popup ", () => {
-  const popup = mount(<PopupTest triggerOn="click" />);
+  const popup = mount(<PopupTest on="click" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
   popup.find("div.popup-overlay").simulate("click");
@@ -87,7 +92,7 @@ test("it shouldn't close on click outside popup ", () => {
 });
 test("it should close on click outside popup (closeOnDocumentClick = true )", () => {
   const popup = mount(
-    <PopupTest triggerOn="click" closeOnDocumentClick={true} />
+    <PopupTest on="click" closeOnDocumentClick={true} />
   );
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
@@ -98,65 +103,65 @@ test("it should close on click outside popup (closeOnDocumentClick = true )", ()
 // position Tests
 
 test("it should rendered in the top left position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="top left" />);
+  const popup = mount(<PopupTest on="click" position="top left" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the top center position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="top center" />);
+  const popup = mount(<PopupTest on="click" position="top center" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the top right position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="top right" />);
+  const popup = mount(<PopupTest on="click" position="top right" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 
 test("it should rendered in the bottom left position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="bottom left" />);
+  const popup = mount(<PopupTest on="click" position="bottom left" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the bottom center position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="bottom center" />);
+  const popup = mount(<PopupTest on="click" position="bottom center" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the bottom right position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="bottom right" />);
+  const popup = mount(<PopupTest on="click" position="bottom right" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 
 test("it should rendered in the right top position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="right top" />);
+  const popup = mount(<PopupTest on="click" position="right top" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the right center position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="right center" />);
+  const popup = mount(<PopupTest on="click" position="right center" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the right bottom position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="right bottom" />);
+  const popup = mount(<PopupTest on="click" position="right bottom" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 
 test("it should rendered in the left top position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="left top" />);
+  const popup = mount(<PopupTest on="click" position="left top" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the left center position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="left center" />);
+  const popup = mount(<PopupTest on="click" position="left center" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });
 test("it should rendered in the left bottom position  ", () => {
-  const popup = mount(<PopupTest triggerOn="click" position="left bottom" />);
+  const popup = mount(<PopupTest on="click" position="left bottom" />);
   popup.find("button").simulate("click");
   expect(shallowToJson(popup)).toMatchSnapshot();
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-testing-library": "^5.1.0",
     "story-router": "^1.0.1",
     "why-did-you-update": "^0.1.1"
   },

--- a/src/Popup.js
+++ b/src/Popup.js
@@ -215,6 +215,7 @@ export default class Popup extends React.PureComponent {
         case "hover":
           triggerProps.onMouseEnter = this.onMouseEnter;
           triggerProps.onMouseLeave = this.onMouseLeave;
+          break;
         case "focus":
           triggerProps.onFocus = this.onMouseEnter;
           break;


### PR DESCRIPTION
This PR adds a missing `break` to prevent the focus event from triggering the popup when `on` is set to `hover`.  

To reproduce:
https://codesandbox.io/s/rwkqrokrro
1. Click Trigger to give the popup element focus
2. Minimize your browser or change to another tab
3. Maximize or navigate back to the sandbox tab
Result: The popup will be visible

I noticed the existing tests were using an invalid `triggerOn` prop instead of `on`, so I updated that throughout `index.test.js`.  

I also updated the initial tests to check for rendering behavior because the shallow json snapshot could not guarantee the popup behavior in browser.