### PR TITLE
Fixed nested lock scroll problem

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ export default class Popup extends React.PureComponent {
       /* eslint-disable-next-line no-undef */
       window.removeEventListener('resize', this.repositionOnResize);
     }
+    this.resetScroll();
   }
 
   repositionOnResize = () => {

--- a/stories/src/NestedLockScroll.js
+++ b/stories/src/NestedLockScroll.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import {Centred} from 'story-router';
+
+import Popup from '../../src';
+
+const NestedLockScrollProps = {
+  closeOnDocumentClick: true,
+  closeOnEscape: true,
+  on: ['click'],
+  position: 'bottom center',
+  arrow: true,
+  offsetX: 0,
+  offsetY: 0,
+};
+
+const NestedLockScroll = props => {
+  return (
+    <div style={{height: '200vh', position: 'relative', textAlign: 'center'}}>
+      <div>Try to scroll down before pressing the button.</div>
+      <Popup {...props} trigger={<button>Button Trigger</button>}>
+        {close => (
+          <div>
+            sum dolor sit amet consectetur adipisicing elit. Nemo voluptas ex,
+            blanditiis reiciendis dolor numquam pariatur facilis, labore, libero
+            nihil asperiores ae facilis quis commodi dolores, at enim. Deserunt
+            qui, officiis culpa optio numquam ullam pariatur voluptas tempora
+            doloremque!
+            <Popup
+              on="click"
+              position="bottom left"
+              closeOnDocumentClick
+              modal
+              lockScroll
+              trigger={<button>Button nested</button>}
+              onClose={close}>
+              <div>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo
+                voluptas ex, blanditiis reiciendis dolor numquam pariatur
+                facilis, labore, libero nihil asperiores ae facilis quis commodi
+                dolores, at enim. Deserunt qui, officiis culpa optio numquam
+                ullam pariatur voluptas tempora doloremque!
+              </div>
+            </Popup>
+          </div>
+        )}
+      </Popup>
+      <div style={{position: 'absolute', bottom: 0}}>
+        Can you still scroll to me?
+      </div>
+    </div>
+  );
+};
+
+const NestedLockScrollStory = {
+  name: 'Nested lock scroll',
+  component: Centred(NestedLockScroll),
+  props: NestedLockScrollProps, // adding props
+};
+export default NestedLockScrollStory;

--- a/stories/src/index.js
+++ b/stories/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Centred } from "story-router";
-import Story from "./Story";
-//import { Centred } from "../../src/utils/";
+import {Centred} from 'story-router';
+import Story from './Story';
+// import { Centred } from "../../src/utils/";
 
 import PopupElementStory from './PopupElement';
 import PopupFuncStory from './PopupFunc';
@@ -14,6 +14,7 @@ import ControlledTooltip from './ControlledTooltip';
 import BoundedTooltip from './BoundedTooltip';
 
 import CellTablePopupStory from './CellTablePopup';
+import NestedLockScrollStory from './NestedLockScroll';
 
 const storyProps = {text: 'Parcel Storybook'};
 const buttonProps = {
@@ -78,4 +79,5 @@ export default [
   PopupInputFocusStory,
   PopupElementStory,
   CellTablePopupStory,
+  NestedLockScrollStory,
 ];


### PR DESCRIPTION
Fixed a bug that permanently locked the scroll when a modal popup with lockscroll enabled was created inside a component that was destroyed when the modal popup was destroyed. This prevented things like opening a modal popup from a tooltip like in the exemple provided.