### PR TITLE
Add className to Popup props in typescript 

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ declare module 'reactjs-popup' {
     contentStyle?: object;
     overlayStyle?: object;
     arrowStyle?: object;
+    className?: string;
     keepTooltipInside?: boolean | string;
   }
 


### PR DESCRIPTION
Hi @yjose .

Is there any reason to remove 'className' from Popup props in typescript ?
If there is no reason, I want to use 'className' in typescript.