### PR TITLE
Reset position of trigger element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ export default class Popup extends React.PureComponent {
 
   componentDidMount() {
     const {closeOnEscape, defaultOpen, repositionOnResize} = this.props;
+    const {modal} = this.state;
     if (defaultOpen) this.setPosition();
     if (closeOnEscape) {
       /* eslint-disable-next-line no-undef */
@@ -74,11 +75,14 @@ export default class Popup extends React.PureComponent {
       /* eslint-disable-next-line no-undef */
       window.addEventListener('resize', this.repositionOnResize);
     }
-    /* eslint-disable-next-line no-undef */
-    const triggerPosition = window
-      .getComputedStyle(this.TriggerEl, null)
-      .getPropertyValue('position');
-    this.setState({triggerPosition});
+
+    if (!modal) {
+      /* eslint-disable-next-line no-undef */
+      const triggerPosition = window
+        .getComputedStyle(this.TriggerEl, null)
+        .getPropertyValue('position');
+      this.setState({triggerPosition});
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -155,13 +159,16 @@ export default class Popup extends React.PureComponent {
 
   closePopup = e => {
     const {onClose} = this.props;
-    const {isOpen, triggerPosition} = this.state;
+    const {isOpen, triggerPosition, modal} = this.state;
     if (!isOpen) return;
     onClose(e);
     this.setState({isOpen: false}, () => {
       this.resetScroll();
     });
-    this.TriggerEl.style.position = triggerPosition;
+    /* eslint-disable-next-line no-undef */
+    if (!modal) {
+      this.TriggerEl.style.position = triggerPosition;
+    }
   };
 
   onMouseEnter = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,8 @@ export default class Popup extends React.PureComponent {
       isOpen: open || defaultOpen,
       modal: modal ? true : !trigger,
       // we create this modal state because the popup can't be a tooltip if the trigger prop doesn't exist
+      triggerPosition: '',
+      // Store the initial trigger element position to reset it on closePopup
     };
   }
 
@@ -72,6 +74,11 @@ export default class Popup extends React.PureComponent {
       /* eslint-disable-next-line no-undef */
       window.addEventListener('resize', this.repositionOnResize);
     }
+    /* eslint-disable-next-line no-undef */
+    const triggerPosition = window
+      .getComputedStyle(this.TriggerEl, null)
+      .getPropertyValue('position');
+    this.setState({triggerPosition});
   }
 
   componentWillReceiveProps(nextProps) {
@@ -148,12 +155,13 @@ export default class Popup extends React.PureComponent {
 
   closePopup = e => {
     const {onClose} = this.props;
-    const {isOpen} = this.state;
+    const {isOpen, triggerPosition} = this.state;
     if (!isOpen) return;
     onClose(e);
     this.setState({isOpen: false}, () => {
       this.resetScroll();
     });
+    this.TriggerEl.style.position = triggerPosition;
   };
 
   onMouseEnter = () => {

--- a/stories/src/PositionRelative.js
+++ b/stories/src/PositionRelative.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import Popup from '../../src';
+
+const PositionRelative = () => {
+  return (
+    <div className="popups">
+      <Popup
+        trigger={
+          <button style={{position: 'static'}} className="trigger">
+            One
+          </button>
+        }>
+        {<div className="content">Content one</div>}
+      </Popup>
+      <Popup
+        trigger={
+          <button style={{position: ''}} className="trigger">
+            Two
+          </button>
+        }>
+        {<div className="content">Content two</div>}
+      </Popup>
+      <Popup
+        trigger={
+          <button style={{position: ''}} className="trigger">
+            Three
+          </button>
+        }
+        modal>
+        {<div className="content">Content three</div>}
+      </Popup>
+    </div>
+  );
+};
+
+const PositionRelativeStory = {
+  name: 'Position Relative',
+  component: PositionRelative,
+  props: {},
+};
+
+export default PositionRelativeStory;

--- a/stories/src/index.js
+++ b/stories/src/index.js
@@ -13,6 +13,7 @@ import ControlledModal from './ControlledModal';
 import ControlledTooltip from './ControlledTooltip';
 import BoundedTooltip from './BoundedTooltip';
 import PopupStyle from './PopupStyle';
+import PositionRelativeStory from './PositionRelative';
 
 import CellTablePopupStory from './CellTablePopup';
 
@@ -88,4 +89,5 @@ export default [
   PopupHandleEventStory,
   NestedLockScrollStory,
   PopupStyle,
+  PositionRelativeStory,
 ];


### PR DESCRIPTION
Reset position of trigger element when closing popup to prevent the element from keeping the property position:relative. Solves issue: #92.