### PR TITLE
Fix typo in menu docs example

### DIFF
--- a/docs/mds/6.menuExamples.md
+++ b/docs/mds/6.menuExamples.md
@@ -23,7 +23,7 @@ const Menu = () => (
     <div className="menu-item"> Menu item 2</div>
     <div className="menu-item"> Menu item 3</div>
     <Popup
-      trigger={<div className="menu-item"> sup Menu </div>}
+      trigger={<div className="menu-item"> Sub menu </div>}
       position="right top"
       on="hover"
       closeOnDocumentClick

--- a/docs/src/examples/SimpleMenu.js
+++ b/docs/src/examples/SimpleMenu.js
@@ -9,7 +9,7 @@ const SimpleMenu = () => (
       <div className="menu-item">Menu item 2</div>
       <div className="menu-item">Menu item 3</div>
       <Popup
-        trigger={<div className="menu-item"> sup Menu </div>}
+        trigger={<div className="menu-item"> Sub menu </div>}
         position="right top"
         on="hover"
         closeOnDocumentClick


### PR DESCRIPTION
Hello,
Just noticed a really small typo while reading the menu examples from the docs. Felt like "sup Menu" should be changed to "Sub menu".