### PR TITLE
Fix: disable scroll on default opened popup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,10 @@ export default class Popup extends React.PureComponent {
 
   componentDidMount() {
     const {closeOnEscape, defaultOpen, repositionOnResize} = this.props;
-    if (defaultOpen) this.setPosition();
+    if (defaultOpen) {
+      this.setPosition();
+      this.lockScroll();
+    }
     if (closeOnEscape) {
       /* eslint-disable-next-line no-undef */
       window.addEventListener('keyup', this.onEscape);

--- a/stories/src/DisabledScrollOnDefaultOpen.js
+++ b/stories/src/DisabledScrollOnDefaultOpen.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Popup from "../../src";
+
+class NoScroll extends React.Component {
+  // thanks to adding this.lockScroll() in componentDidMount scroll is unabled even when 
+  // popup is default open
+  render() {
+    return (
+      <div style={{backgroundColor: 'red', height: '150vh'}}>
+        <Popup
+          trigger={<button>Always open</button>}
+          modal
+          lockScroll={true}
+          defaultOpen={true}>
+          <div className="modal">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Beatae
+            magni omnis delectus nemo, maxime molestiae dolorem numquam
+            mollitia, voluptate ea, accusamus excepturi deleniti ratione
+            sapiente! Laudantium, aperiam doloribus. Odit, aut.
+          </div>
+        </Popup>
+      </div>
+    );
+  }
+}
+
+const NoScrollPopup = {
+  name: 'Disable Scroll on Default Popup Open',
+  component: NoScroll,
+};
+
+export default NoScrollPopup;

--- a/stories/src/DisabledScrollOnDefaultOpen.js
+++ b/stories/src/DisabledScrollOnDefaultOpen.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Popup from "../../src";
 
 class NoScroll extends React.Component {
-  // thanks to adding this.lockScroll() in componentDidMount scroll is unabled even when 
+  // thanks to adding this.lockScroll() in componentDidMount scroll is unabled even when
   // popup is default open
   render() {
     return (

--- a/stories/src/index.js
+++ b/stories/src/index.js
@@ -19,6 +19,7 @@ import CellTablePopupStory from './CellTablePopup';
 import PopupHandleEventStory from './PopupHandleEvent';
 
 import NestedLockScrollStory from './NestedLockScroll';
+import NoScrollPopup from './DisabledScrollOnDefaultOpen';
 
 const storyProps = {text: 'Parcel Storybook'};
 const buttonProps = {
@@ -88,4 +89,5 @@ export default [
   PopupHandleEventStory,
   NestedLockScrollStory,
   PopupStyle,
+  NoScrollPopup,
 ];


### PR DESCRIPTION
## Bug description
When prop `defaultOpen` is set to `true` and `lockScroll` prop is set to `true` the scroll still works.

## Expected behaviour 
`lockScroll` always locks the scroll

## Fix
Invoking function `this.lockScroll()` on `defaultOpen` in `ComponentDidMount()` added.

### Additionally
- 'Disable Scroll on Default Popup Open' story added
- tests run (all green)
- linting tests run (none of my changes affected the results)