### PR TITLE
docs(get-started): Fixing typos

### DIFF
--- a/docs/docs/get-started.mdx
+++ b/docs/docs/get-started.mdx
@@ -50,9 +50,9 @@ If you are planing to create your own css for Modals and tooltip, which the case
 import 'reactjs-popup/dist/index.css';
 ```
 
-## Controll Popup
+## Control Popup
 
-if you need more control over your component `reactjs-popup` we provide function as child pattern to get access to close popup action.
+If you need more control over your component `reactjs-popup` we provide function as child pattern to get access to close popup action.
 
 ```jsx
 const PopupExample = () => (


### PR DESCRIPTION
Hello, I was scrolling through your documentation when a couple typos stood out to me. 

This (very minor) PR fixes a spelling error and a capitalization error on the [Getting Started](https://react-popup.elazizi.com/getting-started) page.