### PR TITLE
refactor: Adding repository field to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,6 @@
     "reactjs-modal",
     "react-tooltip"
   ],
-  "homepage": "https://react-popup.elazizi.com/"
+  "homepage": "https://react-popup.elazizi.com/",
+  "repository": "yjose/reactjs-popup"
 }


### PR DESCRIPTION
This PR is purely for convenience. Adding the `repository` field to the `package.json` provides a quick & easy link for people to use if they've come across your library's page on NPM. 

Yours as-is:
![temp](https://user-images.githubusercontent.com/33403762/92629245-a9235200-f293-11ea-97da-1513291a7e0f.png)

Example with `repository`:
![temp2](https://user-images.githubusercontent.com/33403762/92629247-a9bbe880-f293-11ea-9010-4852e6d6b596.png)

Just a convenience thing. 