### PR TITLE
docs(getting-started): Correcting grammar/spelling/verbiage

### DIFF
--- a/docs/docs/get-started.mdx
+++ b/docs/docs/get-started.mdx
@@ -9,7 +9,7 @@ description: A Simple React popup component.Use it as a tooltip,modal,sub-menu a
 
 ## Installing / Getting started
 
-This package is available in npm repository as `reactjs-popup`. It will work correctly with all popular bundlers.
+This package is available from the NPM repository as `reactjs-popup`. It will work correctly with all popular bundlers.
 
 ```bash
 npm install reactjs-popup --save
@@ -23,7 +23,7 @@ yarn add reactjs-popup -s
 
 ## Include the component
 
-To start using `reactjs-popup` you just need to import the component from the `reactjs-popup` package.
+To start using `reactjs-popup` you just need to import the component from the package.
 
 ```jsx
 import React from 'react';
@@ -38,11 +38,11 @@ const PopupExample = () => (
 
 :::important
 
-Starting from v2, you need to import default styling for modals and tooltips.
+Starting from v2, you need to import the default styling for modals and tooltips.
 
 Default styling is optional and we are using it to make prototyping with `reactjs-popup` more easy.
 
-If you are planing to create your own css for Modals and tooltip, which the case for most cases, You don't need to import default styling.check [css styling section](./css-styling.mdx) for more information.
+If you are planing to create your own CSS for modals and tooltips, which is often the case, you don't need to import the default styling. Check the [CSS styling section](./css-styling.mdx) for more information.
 
 :::
 
@@ -52,7 +52,7 @@ import 'reactjs-popup/dist/index.css';
 
 ## Control Popup
 
-If you need more control over your component `reactjs-popup` we provide function as child pattern to get access to close popup action.
+If you need to have more control over your component, we provide function as child pattern to get access to close popup action.
 
 ```jsx
 const PopupExample = () => (
@@ -69,4 +69,4 @@ const PopupExample = () => (
 );
 ```
 
-> More Example in [Guides Section](./tooltip-examples.mdx)
+> More examples in [Guides Section](./tooltip-examples.mdx)


### PR DESCRIPTION
Minor changes to grammar, spelling, and verbiage on the "getting started" page.