### PR TITLE
Removed `-s` option from the yarn option of 'Installing / Getting started' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install reactjs-popup --save
 Using yarn
 
 ```bash
-yarn add reactjs-popup -s
+yarn add reactjs-popup
 ```
 
 ## Include the Component

--- a/docs/docs/get-started.mdx
+++ b/docs/docs/get-started.mdx
@@ -18,7 +18,7 @@ npm install reactjs-popup --save
 Using yarn
 
 ```bash
-yarn add reactjs-popup -s
+yarn add reactjs-popup
 ```
 
 ## Include the component


### PR DESCRIPTION
Option `-s` of yarn does nothing, so it's unnecessary

See https://classic.yarnpkg.com/en/docs/migrating-from-npm#toc-cli-commands-comparison
Also see https://classic.yarnpkg.com/en/docs/cli/add/