### PR TITLE
scrollX and scrollY replaced with pageXOffset and pageYOffset for IE 9+ compatibility

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -177,8 +177,8 @@ export const Popup = forwardRef<PopupActions, PopupProps>(
         },
         keepTooltipInside
       );
-      contentRef.current.style.top = `${cords.top + window.scrollY}px`;
-      contentRef.current.style.left = `${cords.left + window.scrollX}px`;
+      contentRef.current.style.top = `${cords.top + window.pageYOffset}px`;
+      contentRef.current.style.left = `${cords.left + window.pageXOffset}px`;
       if (arrow && !!arrowRef.current) {
         arrowRef.current.style.transform = cords.transform;
         arrowRef.current.style.setProperty('-ms-transform', cords.transform);


### PR DESCRIPTION
window.scrollX and window.scrollY are undefined in IE 9-11, which results in that the position of the popup when opened equals to 
`top:NaNpx` `bottom: NaNpx` in these versions of IE, and popup is placed directly on the bottom left corner of the page, my changes fix that issue and the popup is positioned correctly in Internet Explorer as well as in other browsers
Support table for scrollX/scrollY according to the MDN
![image](https://user-images.githubusercontent.com/19749374/101931538-3bfcc100-3be2-11eb-833f-46edeb5901c1.png)
Support table for pageXOffset/pageYOffset according to the MDN
![image](https://user-images.githubusercontent.com/19749374/101931706-75353100-3be2-11eb-919e-a505acc2fff5.png)
