### PR TITLE
Fix typo in styled-components import

### DIFF
--- a/docs/docs/styled-styling.mdx
+++ b/docs/docs/styled-styling.mdx
@@ -14,7 +14,7 @@ The Component support styling using `Styled-component`:
 ```jsx
 import React from 'react';
 import Popup from 'reactjs-popup';
-import Styled from 'styled-components';
+import styled from 'styled-components';
 
 const StyledPopup = styled(Popup)`
   // use your custom style for ".popup-overlay"


### PR DESCRIPTION
Noticed that there was a small typo in the styled components import - not a biggie, but it might confuse newcomers :)