### PR TITLE
Allow for more flexibility in how popup-root are created 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,10 @@ const getRootPopup = () => {
   return PopupRoot;
 };
 
+export const PopupGlobalConfig = {
+  getRootPopup
+}
+
 export const Popup = forwardRef<PopupActions, PopupProps>(
   (
     {
@@ -345,7 +349,7 @@ export const Popup = forwardRef<PopupActions, PopupProps>(
     return (
       <>
         {renderTrigger()}
-        {isOpen && ReactDOM.createPortal(content, getRootPopup())}
+        {isOpen && ReactDOM.createPortal(content, PopupGlobalConfig.getRootPopup())}
       </>
     );
   }


### PR DESCRIPTION
Main use case: 
When reactjs-popup portal need to be created within a web-component shadow-dom in order for popup elements to access locally scoped styles.