### PR TITLE
fix: [a11y] set aria-modal true when modal

### DIFF
--- a/__test__/accessability.test.tsx
+++ b/__test__/accessability.test.tsx
@@ -86,6 +86,7 @@ describe('Popup Positions ', () => {
     expect(screen.getByTestId('b1')).toHaveFocus();
     userEvent.click(screen.getByText(/trigger/));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
     fireEvent.keyUp(document, { key: 'Escape', code: 'Escape' });
     expect(screen.queryByRole('dialog')).toBeNull();
     expect(screen.getByText(/trigger/)).toHaveFocus();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -278,6 +278,7 @@ export const Popup = forwardRef<PopupActions, PopupProps>(
           {...addWarperAction()}
           key="C"
           role={isModal ? 'dialog' : 'tooltip'}
+          aria-modal={isModal ? 'true' : null}
           id={popupId.current}
         >
           {arrow && !isModal && (


### PR DESCRIPTION
Minor change to set “aria-modal” to “true” to the dialog container (the div that has the role of “dialog”), in the case of a modal.
This is per WAI-ARIA practices for Dialog (Modal): https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_roles_states_props

I didn’t add any stories to Storybook as it’s seems that adding a unit test for it might be enough… let me know :)