### PR TITLE
Do not add new positions to position

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -158,7 +158,9 @@ const calculatePosition = (
 
   // keepTooltipInside would be activated if the  keepTooltipInside exist or the position is Array
   if (keepTooltipInside || Array.isArray(position))
-    positions = [...positions, ...POSITION_TYPES];
+    if (keepTooltipInside) {
+      positions = [...positions, ...POSITION_TYPES];
+    }
 
   // add viewPort for WarpperBox
   // wrapperBox.top = wrapperBox.top + window.scrollY;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -159,7 +159,7 @@ const calculatePosition = (
   // keepTooltipInside would be activated if the  keepTooltipInside exist or the position is Array
   if (keepTooltipInside || Array.isArray(position))
     if (keepTooltipInside) {
-      positions = [...positions, ...POSITION_TYPES];
+      positions = [...POSITION_TYPES, ...positions];
     }
 
   // add viewPort for WarpperBox


### PR DESCRIPTION
If setup as an array it means users want the positions fixed to the
positions they picked, not every possible positions.

For example, if I set position to 'top left' and 'bottom left' it means
I don't want it to display as 'right center' unless
`keepTooltipInside` is set. In that case the code should just pick the
best options among the given positions, not all positions