### PR TITLE
chore: removed unreachable return statement in hooks

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -13,7 +13,6 @@ export const useOnEscape = (
     document.addEventListener('keyup', listener);
 
     return () => {
-      if (!active) return;
       document.removeEventListener('keyup', listener);
     };
   }, [handler, active]);
@@ -29,7 +28,6 @@ export const useRepositionOnResize = (handler: () => void, active = true) => {
     window.addEventListener('resize', listener);
 
     return () => {
-      if (!active) return;
       window.removeEventListener('resize', listener);
     };
   }, [handler, active]);
@@ -61,7 +59,6 @@ export const useOnClickOutside = (
     document.addEventListener('touchstart', listener);
 
     return () => {
-      if (!active) return;
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
@@ -103,7 +100,6 @@ export const useTabbing = (
     document.addEventListener('keydown', listener);
 
     return () => {
-      if (!active) return;
       document.removeEventListener('keydown', listener);
     };
   }, [contentRef, active]);


### PR DESCRIPTION
src/hooks.tsx have unreachable lines of code in return statements. In each hook return statement, this line can never get called:

```js
if (!active) return;
```

because in the beginning of each useEffect hooks there is the same line. The value of "active" variable does not change in the hook, meaning that "active" is falsy in the beginning of the hook, the hook will return before reaching the last return statement of each hook.