### PR TITLE
fix PopupProps type error

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -28,7 +28,7 @@ export interface PopupProps {
   nested?: boolean;
   defaultOpen?: boolean;
   on?: EventType | EventType[];
-  children: React.ReactNode;
+  children: React.ReactNode | ((close: () => void, isClose?: boolean) => React.ReactNode);
 
   //| ((close: () => void, isOpen: boolean) => React.ReactNode);
   position?: PopupPosition | PopupPosition[];


### PR DESCRIPTION
hi;
there is a type error when you want to pass a function instead a of ReactNode to Popup component.
this issue #315 
i just changed the type of children in PopupProps to handle this.